### PR TITLE
Fix bugs of `TagOptionsFilter`

### DIFF
--- a/lib/remove_data_attributes/railtie.rb
+++ b/lib/remove_data_attributes/railtie.rb
@@ -15,9 +15,9 @@ module RemoveDataAttributes
         ]
 
         if Gem::Version.new(Rails.version) < Gem::Version.new("5.1")
-          ::ActionView::Helpers::TagHelper.prepend(patch)
+          ::ActionView::Helpers::TagHelper.include(patch)
         else
-          ::ActionView::Helpers::TagHelper::TagBuilder.prepend(patch)
+          ::ActionView::Helpers::TagHelper::TagBuilder.include(patch)
         end
       end
     end

--- a/spec/lib/remove_data_attributes/tag_options_filter_spec.rb
+++ b/spec/lib/remove_data_attributes/tag_options_filter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RemoveDataAttributes::TagOptionsFilter do
 
       context "when superclass#tag_options is defined as public method" do
         before do
-          subject.prepend(return_value)
+          subject.include(return_value)
         end
 
         it { expect(subject.public_method_defined?(:tag_options)).to eq true }
@@ -32,7 +32,7 @@ RSpec.describe RemoveDataAttributes::TagOptionsFilter do
       context "when superclass#tag_options is defined as private method" do
         before do
           subject.class_exec { private :tag_options }
-          subject.prepend(return_value)
+          subject.include(return_value)
         end
 
         it { expect(subject.private_method_defined?(:tag_options)).to eq true }
@@ -44,7 +44,7 @@ RSpec.describe RemoveDataAttributes::TagOptionsFilter do
 
       before do
         allow_any_instance_of(subject.class).to receive(:tag_options)
-        subject.class.prepend(return_value)
+        subject.class.include(return_value)
 
         subject.tag_options(*args)
       end


### PR DESCRIPTION
This PR fixes the following bugs of `TagOptionsFilter`:

* `define_method` makes the superclass method public unless we write `private` statement
* `RuntimeError` is raised when passing `nil` to `#tag_options` because `implicit argument passing of super from method defined by define_method() is not supported`.