### PR TITLE
Fix build failure due to Bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ branches:
   only:
     - master
 before_install:
-  - gem update --system --no-doc
-  - gem install bundler
+  - gem update --system 2.7.9 --no-doc
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '~> 1.0'
 before_script:
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter


### PR DESCRIPTION
This PR specifies Bundler version to 1.x because Rails 4 doesn't support Bundler v2.